### PR TITLE
Fix: sainsburys search bar selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.4 (01/03/2026)
+
+- Fix Sainsbury's search bar selector to match website update.
+
 ## v2.2.3 (26/12/2025)
 
 - Update cookie and login handling to match Sainsbury website update.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autogroceries"
-version = "2.2.3"
+version = "2.2.4"
 description = "Automate your grocery shop."
 authors = [
     { name = "David Zhang" },

--- a/src/autogroceries/shopper/sainsburys.py
+++ b/src/autogroceries/shopper/sainsburys.py
@@ -133,7 +133,9 @@ class SainsburysShopper(Shopper):
         """
         # Wait for page to fully load after login
         try:
-            self.page.wait_for_selector("#search-bar-input", timeout=10000)
+            self.page.wait_for_selector(
+                '[data-testid="search-bar-input"] input', timeout=10000
+            )
         except TimeoutError:
             self.logger.warning("Search bar not found - page may not have loaded")
 
@@ -152,9 +154,11 @@ class SainsburysShopper(Shopper):
             n: The desired quantity of the ingredient.
         """
         # There are two search inputs on the same page, use the first.
-        search_input = self.page.locator("#search-bar-input").first
+        search_input = self.page.locator('[data-testid="search-bar-input"] input').first
         search_input.type(ingredient, delay=50)
-        self.page.locator(".search-bar__button").first.click()
+        self.page.locator(
+            '[data-testid="search-bar-input"] button[type="submit"]'
+        ).first.click()
 
         try:
             # If no product found in 10s, skip this ingredient.


### PR DESCRIPTION
Fix #7. 

## Goal                                                                                                  
 
- Fix Sainsbury's search bar selectors to match their website update.                                   
                                                                                                        
## Summary                                                                                               

- Sainsbury's changed their search bar HTML — #search-bar-input is now a data-testid on a wrapper <div> rather than an id on the <input>, and the search button class changed. Updated the three affected selectors in sainsburys.py.
- Bump version to 2.2.4. 